### PR TITLE
修复：roundedwindow.cpp 智能指针的返回

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Build Tarball
+        run: |
+          ls -la
+          mkdir -p lingmo-kwin-plugins
+          cp -R $(ls | grep -xv lingmo-kwin-plugins) lingmo-kwin-plugins/
+          tar -cJf lingmo-kwin-plugins.tar.xz lingmo-kwin-plugins
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+            files: lingmo-kwin-plugins.tar.xz
+            name: Release ${{ github.ref }}
+
+      - name: Cleanup
+        run: rm lingmo-kwin-plugins.tar.xz

--- a/plugins/decoration/lingmoos.json
+++ b/plugins/decoration/lingmoos.json
@@ -2,7 +2,7 @@
     "KPlugin": {
         "Description": "Window decoration",
         "EnabledByDefault": true,
-        "Id": "org.ling.decoration",
+        "Id": "org.lingmo.decoration",
         "Name": "LingmoOS Window Frame",
         "ServiceTypes": [
             "org.kde.kdecoration2"

--- a/plugins/roundedwindow/roundedwindow.cpp
+++ b/plugins/roundedwindow/roundedwindow.cpp
@@ -172,9 +172,7 @@ static std::unique_ptr<KWin::GLShader> getShader()
     stream.flush();
 
     auto shader = KWin::ShaderManager::instance()->generateCustomShader(traits, QByteArray(), source);
-    //shaders.insert(direction, shader);
-    std::unique_ptr<KWin::GLShader> p(shader);
-    return p;
+    return shader;
 }
 
 static KWin::GLTexture *getTexture(int borderRadius)

--- a/plugins/roundedwindow/roundedwindow.cpp
+++ b/plugins/roundedwindow/roundedwindow.cpp
@@ -237,7 +237,7 @@ bool RoundedWindow::supported()
     if (desktop.isEmpty())
         return false;
 
-    return desktop == "Lingmo" && KWin::effects->isOpenGLCompositing() && KWin::GLRenderTarget::supported();
+    return desktop == "Lingmo" && KWin::effects->isOpenGLCompositing() && KWin::GLFramebuffer::supported();
 }
 
 bool RoundedWindow::enabledByDefault()


### PR DESCRIPTION
# unique_ptr不应该被拷贝返回

## 报错：

![8073f178efdf2cb2dfb783f3e5f6656](https://github.com/LingmoOS/lingmo-kwin-plugins/assets/72384746/00ac9ca9-968f-4140-92f3-5d2703d83cdf)

---

## 验证：

```
Building lingmo-kwin-plugins ...
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found X11: /usr/include
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so
-- Looking for XOpenDisplay in /usr/lib/libX11.so;/usr/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Qt5 plugin directory:/usr/lib/qt5/plugins
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /home/intro/Lingmo-Build/LingmoSrcBuild/Src/lingmo-kwin-plugins/build
[  6%] Automatic MOC and UIC for target lingdecoration
[ 13%] Automatic MOC and UIC for target roundedwindow
[ 13%] Built target lingdecoration_autogen
[ 20%] Automatic RCC for resources.qrc
[ 26%] Building CXX object plugins/decoration/CMakeFiles/lingdecoration.dir/lingdecoration_autogen/mocs_compilation.cpp.o
[ 33%] Building CXX object plugins/decoration/CMakeFiles/lingdecoration.dir/x11shadow.cpp.o
[ 46%] Building CXX object plugins/decoration/CMakeFiles/lingdecoration.dir/button.cpp.o
[ 53%] Building CXX object plugins/decoration/CMakeFiles/lingdecoration.dir/lingdecoration_autogen/EWIEGA46WW/qrc_resources.cpp.o
[ 40%] Building CXX object plugins/decoration/CMakeFiles/lingdecoration.dir/decoration.cpp.o
[ 53%] Built target roundedwindow_autogen
[ 60%] Automatic RCC for resources.qrc
[ 66%] Building CXX object plugins/roundedwindow/CMakeFiles/roundedwindow.dir/roundedwindow_autogen/mocs_compilation.cpp.o
[ 73%] Building CXX object plugins/roundedwindow/CMakeFiles/roundedwindow.dir/main.cpp.o
[ 80%] Building CXX object plugins/roundedwindow/CMakeFiles/roundedwindow.dir/roundedwindow.cpp.o
[ 86%] Building CXX object plugins/roundedwindow/CMakeFiles/roundedwindow.dir/roundedwindow_autogen/EWIEGA46WW/qrc_resources.cpp.o
[ 93%] Linking CXX shared module liblingdecoration.so
[ 93%] Built target lingdecoration
[100%] Linking CXX shared module libroundedwindow.so
[100%] Built target roundedwindow
[  6%] Automatic MOC and UIC for target lingdecoration
[ 13%] Automatic MOC and UIC for target roundedwindow
[ 13%] Built target lingdecoration_autogen
[ 13%] Built target roundedwindow_autogen
[ 60%] Built target lingdecoration
[100%] Built target roundedwindow
Install the project...
-- Install configuration: ""
-- Installing: /etc/xdg/kglobalshortcutsrc
-- Installing: /etc/xdg/kwinrc
-- Installing: /etc/xdg/kwinrulesrc
-- Up-to-date: /usr/share/kwin/scripts/linglauncher
-- Installing: /usr/share/kwin/scripts/linglauncher/metadata.desktop
-- Up-to-date: /usr/share/kwin/scripts/linglauncher/contents
-- Installing: /usr/share/kwin/scripts/linglauncher/contents/main.js
-- Up-to-date: /usr/share/kwin/effects/ling_squash
-- Installing: /usr/share/kwin/effects/ling_squash/metadata.json
-- Installing: /usr/share/kwin/effects/ling_squash/metadata.desktop
-- Up-to-date: /usr/share/kwin/effects/ling_squash/contents
-- Up-to-date: /usr/share/kwin/effects/ling_squash/contents/code
-- Installing: /usr/share/kwin/effects/ling_squash/contents/code/main.js
-- Up-to-date: /usr/share/kwin/effects/ling_scale
-- Installing: /usr/share/kwin/effects/ling_scale/metadata.json
-- Installing: /usr/share/kwin/effects/ling_scale/metadata.desktop
-- Up-to-date: /usr/share/kwin/effects/ling_scale/contents
-- Up-to-date: /usr/share/kwin/effects/ling_scale/contents/code
-- Installing: /usr/share/kwin/effects/ling_scale/contents/code/main.js
-- Up-to-date: /usr/share/kwin/effects/ling_popups
-- Installing: /usr/share/kwin/effects/ling_popups/metadata.json
-- Installing: /usr/share/kwin/effects/ling_popups/metadata.desktop
-- Up-to-date: /usr/share/kwin/effects/ling_popups/contents
-- Up-to-date: /usr/share/kwin/effects/ling_popups/contents/code
-- Installing: /usr/share/kwin/effects/ling_popups/contents/code/main.js
-- Up-to-date: /usr/share/kwin/tabbox/ling_thumbnail
-- Installing: /usr/share/kwin/tabbox/ling_thumbnail/metadata.desktop
-- Up-to-date: /usr/share/kwin/tabbox/ling_thumbnail/contents
-- Up-to-date: /usr/share/kwin/tabbox/ling_thumbnail/contents/ui
-- Installing: /usr/share/kwin/tabbox/ling_thumbnail/contents/ui/main.qml
-- Installing: /usr/lib/qt5/plugins/org.kde.kdecoration2/liblingdecoration.so
-- Installing: /usr/lib/qt5/plugins/kwin/effects/plugins/libroundedwindow.so
Finished compiling: lingmo-kwin-plugins
```
> 编译通过