### PR TITLE
修复部分窗口边框错误显示 & 指针返回修改 & 自动打包发布源码

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Build Tarball
+        run: |
+          ls -la
+          mkdir -p lingmo-kwin-plugins
+          cp -R $(ls | grep -xv lingmo-kwin-plugins) lingmo-kwin-plugins/
+          tar -cJf lingmo-kwin-plugins.tar.xz lingmo-kwin-plugins
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+            files: lingmo-kwin-plugins.tar.xz
+            name: Release ${{ github.ref }}
+
+      - name: Cleanup
+        run: rm lingmo-kwin-plugins.tar.xz

--- a/plugins/decoration/lingmoos.json
+++ b/plugins/decoration/lingmoos.json
@@ -2,7 +2,7 @@
     "KPlugin": {
         "Description": "Window decoration",
         "EnabledByDefault": true,
-        "Id": "org.ling.decoration",
+        "Id": "org.lingmo.decoration",
         "Name": "LingmoOS Window Frame",
         "ServiceTypes": [
             "org.kde.kdecoration2"

--- a/plugins/roundedwindow/roundedwindow.cpp
+++ b/plugins/roundedwindow/roundedwindow.cpp
@@ -172,9 +172,7 @@ static std::unique_ptr<KWin::GLShader> getShader()
     stream.flush();
 
     auto shader = KWin::ShaderManager::instance()->generateCustomShader(traits, QByteArray(), source);
-    //shaders.insert(direction, shader);
-    std::unique_ptr<KWin::GLShader> p(shader);
-    return p;
+    return shader;
 }
 
 static KWin::GLTexture *getTexture(int borderRadius)

--- a/plugins/roundedwindow/roundedwindow.cpp
+++ b/plugins/roundedwindow/roundedwindow.cpp
@@ -237,7 +237,7 @@ bool RoundedWindow::supported()
     if (desktop.isEmpty())
         return false;
 
-    return desktop == "Lingmo" && KWin::effects->isOpenGLCompositing() && KWin::GLRenderTarget::supported();
+    return desktop == "Lingmo" && KWin::effects->isOpenGLCompositing() && KWin::GLFramebuffer::supported();
 }
 
 bool RoundedWindow::enabledByDefault()


### PR DESCRIPTION
# 注意
其中指针返回的修改严格意义上并不准确 #4 
但对于目前使用暂无影响，可后续修改...

# 对于修改：
- 边框错误
![8ff0391661b5ceed2801ae2d4bb7fbd7](https://github.com/LingmoOS/lingmo-kwin-plugins/assets/72384746/fbd38dfd-0b4a-47d0-ae3c-4d39b67bbd40)
经过调试得知为kwin报错 `org.lingmo.decoration not found.`
经排查为 `lingmoos.json` 中ID配置错误导致的无法读取，
经修复：
![62ee8bedfbe3ac8d4b376161f8430862](https://github.com/LingmoOS/lingmo-kwin-plugins/assets/72384746/e8dc1858-e386-4063-8bb1-9f5c00c84314)

- 自动发布
其他项目同理，建议添加由版本发布触发的源码releases，方便用于包的编译，
比起Github自带的打包下载，在文件命名上更符合规范，且可以进行版本回溯。
btw，已经fork并对多数必需仓库编写了 `Release Actions ` ，后续将一并PR

# Best Wishes...